### PR TITLE
fix(index.html): Change the typo in 'A commit messages consists'

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 
         <article>
             <h3>Message Structure</h3>
-            <p>A commit messages consists of three distinct parts separated by a blank line: the title, an optional body and an optional footer. The layout looks like this:</p>
+            <p>A commit message consists of three distinct parts separated by a blank line: the title, an optional body and an optional footer. The layout looks like this:</p>
 
             <pre><code>type: Subject
 


### PR DESCRIPTION
While reading through your very helpful git style guide, I found a typographical error under "Message Structure" subheading on the first line. I changed 'A commit messages consists' to 'A commit message consists'.